### PR TITLE
Fix multiline and maxLength not showing for shared users

### DIFF
--- a/app.js
+++ b/app.js
@@ -431,12 +431,12 @@ const app = createApp({
             const meta = columnMetadata.value[el.fieldName];
 
             // multiline: only valid for pure text fields
-            if (el.multiline && !isPureTextFieldByMeta(meta)) {
+            if (el.multiline && meta && !isPureTextFieldByMeta(meta)) {
               delete el.multiline;
             }
 
             // maxLength: only valid for text/numeric/int fields
-            if (el.maxLength != null && !isTextOrNumericFieldByMeta(meta)) {
+            if (el.maxLength != null && meta && !isTextOrNumericFieldByMeta(meta)) {
               delete el.maxLength;
             }
 


### PR DESCRIPTION
## Summary
- Fix multiline textarea and maxLength validation not appearing for users accessing a shared document

## Problem
When a user with limited access (e.g. viewer) opened the form, the `multiline` and `maxLength` properties were incorrectly deleted during configuration loading.

This happened because `isPureTextFieldByMeta(meta)` returns `false` when `meta` is `undefined` (metadata unavailable), triggering the cleanup code to remove these properties.

## Fix
Added a `meta &&` check before deleting properties. Now the cleanup only happens when metadata is available AND confirms the field type doesn't support these properties.