### PR TITLE
Fix removing highlight on partial text selection

### DIFF
--- a/app.js
+++ b/app.js
@@ -730,7 +730,9 @@ const app = createApp({
       if (command === 'foreColor') {
         document.execCommand('foreColor', false, '#000000');
       } else {
-        document.execCommand('backColor', false, 'transparent');
+        // Using white background because 'transparent' doesn't work with partial selections
+        // TODO: if adding dark mode, use the editor background color
+        document.execCommand('backColor', false, '#FFFFFF');
       }
       colorPicker.show = false;
       richEditor.value?.focus();


### PR DESCRIPTION
## Summary
- Fix highlight removal not working when only part of the highlighted text is selected

## Problem
When selecting only a portion of highlighted text and clicking the "no color" button, the highlight was not removed.

This happened because `execCommand('backColor', 'transparent')` doesn't work well with partial selections - it creates a nested span with transparent background instead of actually removing the highlight.

## Fix
Use white (`#FFFFFF`) instead of `transparent` when removing highlight. This ensures the background is visually cleared regardless of selection size.