### PR TITLE
Add DateTime field support

### DIFF
--- a/app.js
+++ b/app.js
@@ -189,6 +189,7 @@ const app = createApp({
     // Emoji list
     const emojis = ['😀', '😊', '👍', '❤️', '⭐', '🎉', '✅', '❌', '⚠️', '💡', '📌', '🔥', '💪', '🙏', '👏', '🤝'];
 
+
     // -------------------------------------------------------------------------
     // COMPUTED PROPERTIES
     // -------------------------------------------------------------------------
@@ -374,7 +375,8 @@ const app = createApp({
             refTable,                   // Target table name for Ref/RefList
             refChoices,                 // [{id, label}] for Ref/RefList dropdowns
             isBool: type === 'Bool',
-            isDate: type === 'Date' || type === 'DateTime',
+            isDate: type === 'Date',
+            isDateTime: type.startsWith('DateTime:'),
             isNumeric: type === 'Numeric',
             isInt: type === 'Int',
             isFormula: colsInfo.isFormula?.[i] === true && colsInfo.formula?.[i]?.length > 0,
@@ -879,7 +881,7 @@ const app = createApp({
     // Check if metadata indicates a text or numeric field (can have maxLength validation)
     function isTextOrNumericFieldByMeta(meta) {
       if (!meta) return false;
-      return !meta.isBool && !meta.isDate && !meta.isMultiple && !meta.isAttachment &&
+      return !meta.isBool && !meta.isDate && !meta.isDateTime && !meta.isMultiple && !meta.isAttachment &&
         (!meta.choices || meta.choices.length === 0) &&
         (!meta.isRef || meta.refChoices.length === 0);
     }
@@ -990,6 +992,7 @@ const app = createApp({
       }
       return html;
     }
+
 
     // Check if a field should display a select dropdown (Choice or Ref)
     function hasSelectOptions(element) {
@@ -1125,6 +1128,9 @@ const app = createApp({
         // Numeric: parse float, accepting comma as decimal separator
         } else if (meta?.isNumeric || meta?.isInt) {
           fields[col] = value ? parseFloat(value.toString().replace(',', '.')) : null;
+        // Date/DateTime: convert to timestamp in seconds
+        } else if (meta?.isDate || meta?.isDateTime) {
+          fields[col] = value ? Math.floor(new Date(value).getTime() / 1000) : null;
         // Default (text): return sanitized string
         } else {
           fields[col] = value?.toString().trim() || null;

--- a/index.html
+++ b/index.html
@@ -163,6 +163,12 @@
                 </div>
               </div>
             </div>
+            <!-- DateTime -->
+            <input
+              v-else-if="columnMetadata[element.fieldName]?.isDateTime"
+              type="datetime-local"
+              v-model="formData[element.fieldName]"
+            >
             <!-- Date -->
             <input
               v-else-if="columnMetadata[element.fieldName]?.isDate"


### PR DESCRIPTION
## Summary
- Add support for DateTime columns (e.g. `DateTime:Europe/Paris`) in addition to Date columns

## Problem
The form only supported `Date` columns. `DateTime` columns were treated the same as `Date`, showing only a date picker without time selection.

## Fix
- Separate `isDate` (for `Date` type) and `isDateTime` (for `DateTime:*` types) in column metadata
- Add a `datetime-local` input for DateTime fields
- Convert both Date and DateTime values to timestamps (seconds) when submitting to Grist

Closes #10