### PR TITLE
Lazy load ref data and cap dropdown options for large tables

### DIFF
--- a/app.js
+++ b/app.js
@@ -1051,13 +1051,23 @@ const app = createApp({
       return opt ? opt.label : value;
     }
 
+    // Max options displayed in a dropdown (avoid rendering 45k DOM nodes)
+    const MAX_DISPLAYED_OPTIONS = 100;
+
     // Get filtered options based on search query
-    // Filters on option label (case-insensitive)
+    // Results are capped at MAX_DISPLAYED_OPTIONS to avoid DOM performance issues
     function getFilteredOptions(element) {
-      const options = getSelectOptions(element);
+      let options = getSelectOptions(element);
       const query = (searchQuery[element.fieldName] || '').toLowerCase();
-      if (!query) return options;
-      return options.filter(o => o.label.toLowerCase().includes(query));
+      if (query) {
+        options = options.filter(o => o.label.toLowerCase().includes(query));
+      }
+      return options.slice(0, MAX_DISPLAYED_OPTIONS);
+    }
+
+    // Check if there are more options than what's displayed
+    function hasMoreOptions(element) {
+      return getSelectOptions(element).length > MAX_DISPLAYED_OPTIONS;
     }
 
     // Check if option is selected
@@ -1346,6 +1356,7 @@ const app = createApp({
       toggleDropdown,
       getOptionLabel,
       getFilteredOptions,
+      hasMoreOptions,
       isOptionSelected,
       selectOption,
       removeSelection,

--- a/app.js
+++ b/app.js
@@ -148,6 +148,7 @@ const app = createApp({
     // Custom select state
     const openDropdown = ref(null);       // Currently open dropdown (fieldName)
     const searchQuery = reactive({});     // Search query per field
+    const loadingDropdown = ref(null);    // fieldName currently loading ref data
 
     // "Edit popup" (used to edit text) state
     const editPopup = reactive({
@@ -166,7 +167,8 @@ const app = createApp({
       operator: 'equals',
       value: '',
       values: [],
-      hasExisting: false
+      hasExisting: false,
+      tooManyValues: false
     });
 
     // "Validation popup" (used for maxLength) state
@@ -240,7 +242,7 @@ const app = createApp({
         const meta = columnMetadata.value[el.fieldName];
         if (!meta) return false;
         return (meta.choices?.length > 0 && !meta.isMultiple) ||
-          (meta.isRef && !meta.isMultiple && meta.refChoices?.length > 0);
+          (meta.isRef && !meta.isMultiple);
       });
     });
 
@@ -327,7 +329,6 @@ const app = createApp({
           const type = colsInfo.type[i];  // eg: "Text", "Int", "Ref:Clients", "ChoiceList"
           let choices = null;
           let refTable = null;
-          let refChoices = [];
 
           // For Choice/ChoiceList columns: extract choices from widgetOptions JSON
           // Example: {"choices": ["Option A", "Option B", "Option C"]}
@@ -348,31 +349,15 @@ const app = createApp({
             refTable = type.substring(8);
           }
 
-          // For Ref/RefList: fetch target table and build dropdown choices
+          // For Ref/RefList: resolve display column name from visibleCol.
+          // Actual data fetch is deferred to first dropdown open (see ensureRefDataLoaded)
+          // to avoid blocking the form load for large tables (e.g. 45k communes).
+          let refDisplayCol = null;
           if (refTable) {
-            try {
-              const refData = await grist.docApi.fetchTable(refTable);
-
-              // visibleCol: for Reference columns: numeric ID of the display column
-              let displayColId = null;
-              const visibleColRef = colsInfo.visibleCol?.[i];
-
-              // Resolve numeric ID -> column name using our index
-              if (visibleColRef && visibleColRef !== 0 && colById[visibleColRef]) {
-                displayColId = colById[visibleColRef].colId;
-              }
-
-              // Fallback: use first non-system column if visibleCol not set
-              if (!displayColId || !refData[displayColId]) {
-                displayColId = Object.keys(refData).find(k => k !== 'id' && k !== 'manualSort');
-              }
-
-              // Build choices array: [{id: 1, label: "Client A"}, {id: 2, label: "Client B"}]
-              refChoices = refData.id.map((id, idx) => ({
-                id,
-                label: displayColId && refData[displayColId] ? refData[displayColId][idx] : id
-              }));
-            } catch (e) { }
+            const visibleColRef = colsInfo.visibleCol?.[i];
+            if (visibleColRef && visibleColRef !== 0 && colById[visibleColRef]) {
+              refDisplayCol = colById[visibleColRef].colId;
+            }
           }
 
           // Store all metadata for this column
@@ -383,7 +368,9 @@ const app = createApp({
             isMultiple: type === 'ChoiceList' || type.startsWith('RefList:'),
             isRef: type.startsWith('Ref:') || type.startsWith('RefList:'),
             refTable,                   // Target table name for Ref/RefList
-            refChoices,                 // [{id, label}] for Ref/RefList dropdowns
+            refDisplayCol,              // Display column name (from visibleCol), resolved on data load
+            refChoices: [],             // [{id, label}] populated on first dropdown open
+            refDataLoaded: false,       // Whether ref data has been fetched
             isBool: type === 'Bool',
             isDate: type === 'Date' || type === 'DateTime',
             isNumeric: type === 'Numeric',
@@ -456,7 +443,7 @@ const app = createApp({
               const condMeta = columnMetadata.value[el.conditional.field];
               const isValidConditionField = condMeta && (
                 (condMeta.choices?.length > 0 && !condMeta.isMultiple) ||
-                (condMeta.isRef && !condMeta.isMultiple && condMeta.refChoices?.length > 0)
+                (condMeta.isRef && !condMeta.isMultiple)
               );
               if (!isValidConditionField) {
                 delete el.conditional;
@@ -808,9 +795,10 @@ const app = createApp({
     // -------------------------------------------------------------------------
 
     // Show popup to configure conditional display rules for a field
-    function showFilterPopup(index) {
+    async function showFilterPopup(index) {
       const el = formElements.value[index];
       filterPopup.index = index;
+      filterPopup.tooManyValues = false;
 
       // Check if this field already has a conditional rule configured
       filterPopup.hasExisting = !!el.conditional;
@@ -820,7 +808,7 @@ const app = createApp({
         filterPopup.field = el.conditional.field;
         filterPopup.operator = el.conditional.operator || 'equals';
         filterPopup.value = el.conditional.value;
-        updateFilterValues();
+        await updateFilterValues();
       } else {
         filterPopup.field = '';
         filterPopup.operator = 'equals';
@@ -832,10 +820,15 @@ const app = createApp({
       showOverlay.value = true;
     }
 
+    // Max values allowed in the conditional popup (native <select> can't handle 45k options)
+    const MAX_CONDITIONAL_VALUES = 200;
+
     // Populate value dropdown based on selected conditional field
     // Shows either reference choices (for Ref columns) or choice options (for Choice columns)
-    function updateFilterValues() {
-      // Reset to empty if no field selected
+    // Async because ref data may need to be lazy-loaded
+    async function updateFilterValues() {
+      filterPopup.tooManyValues = false;
+
       if (!filterPopup.field) {
         filterPopup.values = [];
         return;
@@ -847,10 +840,15 @@ const app = createApp({
         return;
       }
 
-      // For Ref columns: use refChoices (id + label from referenced table)
-      if (meta.refChoices?.length > 0) {
+      // For Ref columns: ensure data is loaded then use refChoices
+      if (meta.isRef) {
+        await ensureRefDataLoaded(filterPopup.field);
+        if (meta.refChoices.length > MAX_CONDITIONAL_VALUES) {
+          filterPopup.tooManyValues = true;
+          filterPopup.values = [];
+          return;
+        }
         filterPopup.values = meta.refChoices;
-      // For Choice columns: use choices array directly
       } else if (meta.choices?.length > 0) {
         filterPopup.values = meta.choices.map(c => ({ id: c, label: c }));
       } else {
@@ -892,7 +890,7 @@ const app = createApp({
       if (!meta) return false;
       return !meta.isBool && !meta.isDate && !meta.isMultiple && !meta.isAttachment &&
         (!meta.choices || meta.choices.length === 0) &&
-        (!meta.isRef || meta.refChoices.length === 0);
+        !meta.isRef;
     }
 
     // Check if metadata indicates a pure text field (can be multiline)
@@ -1006,7 +1004,7 @@ const app = createApp({
     function hasSelectOptions(element) {
       const meta = columnMetadata.value[element.fieldName];
       if (!meta) return false;
-      return (meta.choices?.length > 0) || (meta.isRef && meta.refChoices?.length > 0);
+      return (meta.choices?.length > 0) || meta.isRef;
     }
 
     // Get options for select dropdown
@@ -1029,18 +1027,45 @@ const app = createApp({
     }
 
     // -------------------------------------------------------------------------
+    // LAZY LOADING FOR REF/REFLIST DATA
+    // -------------------------------------------------------------------------
+
+    // Fetch ref table data on first dropdown open (not at form load).
+    // For a 45k communes table, this avoids blocking the initial render.
+    async function ensureRefDataLoaded(colId) {
+      const meta = columnMetadata.value[colId];
+      if (!meta?.isRef || !meta.refTable || meta.refDataLoaded) return;
+
+      loadingDropdown.value = colId;
+      try {
+        const refData = await grist.docApi.fetchTable(meta.refTable);
+        const displayColId = meta.refDisplayCol;
+
+        meta.refChoices = refData.id.map((id, idx) => ({
+          id,
+          label: displayColId && refData[displayColId] ? refData[displayColId][idx] : id
+        }));
+        meta.refDataLoaded = true;
+      } catch (e) {
+        errors[colId] = 'Erreur lors du chargement des données';
+      }
+      loadingDropdown.value = null;
+    }
+
+    // -------------------------------------------------------------------------
     // CUSTOM SELECT (with search and chips)
     // -------------------------------------------------------------------------
 
-    // Toggle dropdown open/close
-    function toggleDropdown(fieldName) {
+    // Toggle dropdown open/close (async for lazy loading ref data)
+    // Opens the dropdown immediately, shows "Chargement..." inside while fetching
+    async function toggleDropdown(fieldName) {
       if (openDropdown.value === fieldName) {
-        // Already open → close it
         openDropdown.value = null;
       } else {
-        // Closed → open it and reset search
         openDropdown.value = fieldName;
         searchQuery[fieldName] = '';
+        // Load ref data if not yet fetched (dropdown is already open, shows loading state)
+        await ensureRefDataLoaded(fieldName);
       }
     }
 
@@ -1302,6 +1327,7 @@ const app = createApp({
       emojis,
       activeFormats,
       openDropdown,
+      loadingDropdown,
       searchQuery,
 
       // Computed

--- a/app.js
+++ b/app.js
@@ -145,6 +145,10 @@ const app = createApp({
     const dragOverIndex = ref(null);      // Index of element being dragged over
     const dragPosition = ref('');         // 'top' or 'bottom' drop position
 
+    // Custom select state
+    const openDropdown = ref(null);       // Currently open dropdown (fieldName)
+    const searchQuery = reactive({});     // Search query per field
+
     // "Edit popup" (used to edit text) state
     const editPopup = reactive({
       show: false,
@@ -257,6 +261,13 @@ const app = createApp({
         getColumnMetadata().then(meta => {
           columnMetadata.value = meta;
         });
+      });
+
+      // Close dropdowns when clicking outside
+      document.addEventListener('click', (e) => {
+        if (!e.target.closest('.custom-select')) {
+          openDropdown.value = null;
+        }
       });
     });
 
@@ -1018,6 +1029,82 @@ const app = createApp({
     }
 
     // -------------------------------------------------------------------------
+    // CUSTOM SELECT (with search and chips)
+    // -------------------------------------------------------------------------
+
+    // Toggle dropdown open/close
+    function toggleDropdown(fieldName) {
+      if (openDropdown.value === fieldName) {
+        // Already open → close it
+        openDropdown.value = null;
+      } else {
+        // Closed → open it and reset search
+        openDropdown.value = fieldName;
+        searchQuery[fieldName] = '';
+      }
+    }
+
+    // Get label for a selected value
+    function getOptionLabel(element, value) {
+      const options = getSelectOptions(element);
+      const opt = options.find(o => o.id === value);
+      return opt ? opt.label : value;
+    }
+
+    // Get filtered options based on search query
+    // Filters on option label (case-insensitive)
+    function getFilteredOptions(element) {
+      const options = getSelectOptions(element);
+      const query = (searchQuery[element.fieldName] || '').toLowerCase();
+      if (!query) return options;
+      return options.filter(o => o.label.toLowerCase().includes(query));
+    }
+
+    // Check if option is selected
+    function isOptionSelected(fieldName, optionId) {
+      const meta = columnMetadata.value[fieldName];
+      if (meta?.isMultiple) {
+        return (formData[fieldName] || []).includes(optionId);
+      }
+      return formData[fieldName] === optionId;
+    }
+
+    // Select an option (handles both single and multiple)
+    function selectOption(element, optionId) {
+      const fieldName = element.fieldName;
+      const meta = columnMetadata.value[fieldName];
+
+      if (meta?.isMultiple) {
+        // Multiple: toggle selection
+        const current = formData[fieldName] || [];
+        const index = current.indexOf(optionId);
+        if (index > -1) {
+          // Already selected → remove it
+          current.splice(index, 1);
+        } else {
+          // Not selected → add it
+          current.push(optionId);
+        }
+        formData[fieldName] = [...current];
+      } else {
+        // Single: select and close
+        formData[fieldName] = optionId;
+        openDropdown.value = null;
+      }
+    }
+
+    // Remove a selection from chips (for multiple)
+    function removeSelection(fieldName, value) {
+      const current = formData[fieldName] || [];
+      const index = current.indexOf(value);
+      if (index > -1) {
+        // Found in array → remove it
+        current.splice(index, 1);
+        formData[fieldName] = [...current];
+      }
+    }
+
+    // -------------------------------------------------------------------------
     // FORM VALIDATION
     // -------------------------------------------------------------------------
 
@@ -1204,6 +1291,8 @@ const app = createApp({
       editorColors,
       emojis,
       activeFormats,
+      openDropdown,
+      searchQuery,
 
       // Computed
       containerStyle,
@@ -1254,6 +1343,12 @@ const app = createApp({
       getLabelHtml,
       hasSelectOptions,
       getSelectOptions,
+      toggleDropdown,
+      getOptionLabel,
+      getFilteredOptions,
+      isOptionSelected,
+      selectOption,
+      removeSelection,
       submitForm
     };
   }

--- a/index.html
+++ b/index.html
@@ -216,6 +216,9 @@
                   <div v-if="getFilteredOptions(element).length === 0" class="no-results">
                     Aucun résultat
                   </div>
+                  <div v-if="hasMoreOptions(element)" class="more-results">
+                    Affinez votre recherche pour voir plus de résultats
+                  </div>
                 </div>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -196,30 +196,37 @@
                 <span class="dropdown-arrow">▼</span>
               </div>
               <div class="custom-select-dropdown" v-if="openDropdown === element.fieldName">
-                <input
-                  type="text"
-                  class="search-input"
-                  placeholder="Rechercher..."
-                  v-model="searchQuery[element.fieldName]"
-                  @click.stop
-                >
-                <div class="options-list">
-                  <div
-                    v-for="opt in getFilteredOptions(element)"
-                    :key="opt.id"
-                    class="option"
-                    :class="{ selected: isOptionSelected(element.fieldName, opt.id) }"
-                    @click.stop="selectOption(element, opt.id)"
-                  >
-                    {{ opt.label }}
-                  </div>
-                  <div v-if="getFilteredOptions(element).length === 0" class="no-results">
-                    Aucun résultat
-                  </div>
-                  <div v-if="hasMoreOptions(element)" class="more-results">
-                    Affinez votre recherche pour voir plus de résultats
-                  </div>
+                <!-- Loading state while fetching ref data -->
+                <div v-if="loadingDropdown === element.fieldName" class="dropdown-loading">
+                  Chargement...
                 </div>
+                <!-- Normal dropdown content -->
+                <template v-else>
+                  <input
+                    type="text"
+                    class="search-input"
+                    placeholder="Rechercher..."
+                    v-model="searchQuery[element.fieldName]"
+                    @click.stop
+                  >
+                  <div class="options-list">
+                    <div
+                      v-for="opt in getFilteredOptions(element)"
+                      :key="opt.id"
+                      class="option"
+                      :class="{ selected: isOptionSelected(element.fieldName, opt.id) }"
+                      @click.stop="selectOption(element, opt.id)"
+                    >
+                      {{ opt.label }}
+                    </div>
+                    <div v-if="getFilteredOptions(element).length === 0" class="no-results">
+                      Aucun résultat
+                    </div>
+                    <div v-if="hasMoreOptions(element)" class="more-results">
+                      Affinez votre recherche pour voir plus de résultats
+                    </div>
+                  </div>
+                </template>
               </div>
             </div>
             <!-- Textarea (multiline) -->
@@ -317,7 +324,10 @@
           <option value="notEquals">n'est pas égal à</option>
         </select>
       </div>
-      <div class="filter-row">
+      <div class="filter-row" v-if="filterPopup.tooManyValues">
+        <div class="filter-too-many">Cette colonne contient trop de valeurs pour être utilisée comme condition.</div>
+      </div>
+      <div class="filter-row" v-else>
         <select v-model="filterPopup.value">
           <option value="">-- Sélectionner une valeur --</option>
           <option v-for="v in filterPopup.values" :key="v.id" :value="v.id">{{ v.label }}</option>

--- a/index.html
+++ b/index.html
@@ -169,30 +169,56 @@
               type="date"
               v-model="formData[element.fieldName]"
             >
-            <!-- Select multiple (ChoiceList, RefList) -->
-            <select
-              v-else-if="columnMetadata[element.fieldName]?.isMultiple"
-              multiple
-              v-model="formData[element.fieldName]"
-            >
-              <option
-                v-for="opt in getSelectOptions(element)"
-                :key="opt.id"
-                :value="opt.id"
-              >{{ opt.label }}</option>
-            </select>
-            <!-- Select simple (Choice, Ref) -->
-            <select
+            <!-- Custom select (Choice, ChoiceList, Ref, RefList) -->
+            <div
               v-else-if="hasSelectOptions(element)"
-              v-model="formData[element.fieldName]"
+              class="custom-select"
+              :class="{ open: openDropdown === element.fieldName }"
             >
-              <option value="">-- Sélectionner --</option>
-              <option
-                v-for="opt in getSelectOptions(element)"
-                :key="opt.id"
-                :value="opt.id"
-              >{{ opt.label }}</option>
-            </select>
+              <!-- Chips above the select (for multiple) -->
+              <div class="chips-container" v-if="columnMetadata[element.fieldName]?.isMultiple && formData[element.fieldName]?.length">
+                <span
+                  v-for="val in formData[element.fieldName]"
+                  :key="val"
+                  class="chip"
+                >
+                  {{ getOptionLabel(element, val) }}
+                  <span class="chip-remove" @click.stop="removeSelection(element.fieldName, val)">×</span>
+                </span>
+              </div>
+              <div class="custom-select-display" @click="toggleDropdown(element.fieldName)">
+                <!-- Placeholder for multiple -->
+                <span v-if="columnMetadata[element.fieldName]?.isMultiple" class="placeholder">Choisir</span>
+                <!-- Single selection display -->
+                <span v-else class="single-value">
+                  {{ formData[element.fieldName] ? getOptionLabel(element, formData[element.fieldName]) : '-- Sélectionner --' }}
+                </span>
+                <span class="dropdown-arrow">▼</span>
+              </div>
+              <div class="custom-select-dropdown" v-if="openDropdown === element.fieldName">
+                <input
+                  type="text"
+                  class="search-input"
+                  placeholder="Rechercher..."
+                  v-model="searchQuery[element.fieldName]"
+                  @click.stop
+                >
+                <div class="options-list">
+                  <div
+                    v-for="opt in getFilteredOptions(element)"
+                    :key="opt.id"
+                    class="option"
+                    :class="{ selected: isOptionSelected(element.fieldName, opt.id) }"
+                    @click.stop="selectOption(element, opt.id)"
+                  >
+                    {{ opt.label }}
+                  </div>
+                  <div v-if="getFilteredOptions(element).length === 0" class="no-results">
+                    Aucun résultat
+                  </div>
+                </div>
+              </div>
+            </div>
             <!-- Textarea (multiline) -->
             <textarea
               v-else-if="element.multiline"

--- a/style.css
+++ b/style.css
@@ -503,6 +503,20 @@ select[multiple] option:checked {
   text-align: center;
 }
 
+.filter-too-many {
+  font-size: 13px;
+  color: #d32f2f;
+  font-style: italic;
+  padding: 4px 0;
+}
+
+.dropdown-loading {
+  padding: 12px;
+  color: #999;
+  font-size: 14px;
+  text-align: center;
+}
+
 .more-results {
   padding: 8px 12px;
   font-size: 12px;

--- a/style.css
+++ b/style.css
@@ -371,6 +371,139 @@ select[multiple] option:checked {
 }
 
 /* -----------------------------------------------------------------------------
+   Custom select (with search and chips)
+   ----------------------------------------------------------------------------- */
+
+.custom-select {
+  position: relative;
+  width: 100%;
+}
+
+.chips-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+  margin-bottom: 8px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 8px;
+  background: #e8f0fe;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+  color: #0d5bba;
+}
+
+.chip-remove {
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+  color: #666;
+  position: relative;
+  top: -1px;
+}
+
+.chip-remove:hover {
+  color: #d32f2f;
+}
+
+.custom-select-display {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  min-height: 42px;
+}
+
+.custom-select.open .custom-select-display {
+  border-color: #2383e2;
+}
+
+.placeholder,
+.single-value {
+  color: #37352f;
+  font-size: 14px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+}
+
+.placeholder {
+  color: #999;
+}
+
+.dropdown-arrow {
+  font-size: 10px;
+  color: #666;
+  margin-left: 8px;
+}
+
+.custom-select-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+  margin-top: 4px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+}
+
+.search-input {
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  border-bottom: 1px solid #e0e0e0;
+  border-radius: 4px 4px 0 0;
+  font-size: 14px;
+  font-family: inherit;
+}
+
+.search-input:focus {
+  outline: none;
+}
+
+.options-list {
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.option {
+  padding: 10px 12px;
+  cursor: pointer;
+  font-size: 14px;
+  font-family: inherit;
+}
+
+.option:hover {
+  background: #f5f5f5;
+}
+
+.option.selected {
+  background: #e8f0fe;
+  color: #1a73e8;
+}
+
+.no-results {
+  padding: 10px 12px;
+  color: #999;
+  font-size: 14px;
+  text-align: center;
+}
+
+/* -----------------------------------------------------------------------------
    Messages et erreurs
    ----------------------------------------------------------------------------- */
 

--- a/style.css
+++ b/style.css
@@ -503,6 +503,15 @@ select[multiple] option:checked {
   text-align: center;
 }
 
+.more-results {
+  padding: 8px 12px;
+  font-size: 12px;
+  color: #999;
+  font-style: italic;
+  text-align: center;
+  border-top: 1px solid #e0e0e0;
+}
+
 /* -----------------------------------------------------------------------------
    Messages et erreurs
    ----------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

- **Lazy loading (Ref/RefList columns only):** Reference table data (e.g. 45k communes) is no longer fetched during form initialization in `getColumnMetadata()`. Data is fetched on demand the first time a Ref/RefList dropdown is opened, via `ensureRefDataLoaded()`. The dropdown opens immediately on click and shows "Chargement..." inside the panel while data is being fetched. Once loaded, data is cached in memory (`refDataLoaded` flag) so subsequent opens are instant.
- **Display cap (all dropdown columns):** Dropdown options are capped at 100 displayed results to avoid freezing the DOM on large tables, with a "Affinez votre recherche" message. This applies to all dropdown types (Choice, ChoiceList, Ref, RefList).
- **Conditional popup guard:** The conditional display popup shows a warning when a Ref column has too many values (>200) to be used as a condition.

## Why

Previously, `getColumnMetadata()` called `fetchTable()` for every Ref/RefList column at form load time. For large reference tables (e.g. 45k communes), this blocked the form render for up to 2 minutes. Then, rendering all options in the DOM caused the dropdown to freeze on open.

## Limitation

The Grist Plugin API `fetchTable()` does not support pagination or server-side filtering. The full referenced table must still be fetched for client-side search to work across all rows. This means:

- **First click** on a large Ref/RefList dropdown: a few seconds to fetch all data (with "Chargement..." displayed inside the dropdown)
- **Subsequent clicks**: instant (data is cached in memory)

This is the best we can achieve with the current Grist Plugin API. The key improvement is that this fetch no longer blocks the initial form render, and the dropdown no longer freezes thanks to the 100 results cap.

## Merge order

This PR depends on #20 (custom select with search) and should be merged **after** #20.

## Test plan

- [ ] Open a form with a large Ref column (e.g. 45k rows) — form should load instantly instead of blocking for minutes
- [ ] Click a large Ref dropdown — should show "Chargement..." inside the dropdown, then display options (max 100)
- [ ] Search within the dropdown — should filter across all rows, still capped at 100 displayed
- [ ] Click the same dropdown again — should open instantly (cached)
- [ ] Click a Choice/ChoiceList dropdown — should open instantly (no lazy loading needed), capped at 100
- [ ] Open the conditional display popup on a Ref field with many values — should show "too many values" warning
- [ ] Open the conditional display popup on a Ref field with few values — should work normally