### PR TITLE
Fix form reset after submit

### DIFF
--- a/app.js
+++ b/app.js
@@ -1159,11 +1159,11 @@ const app = createApp({
         formElements.value.forEach(el => {
           if (el.type === 'field') {
             const meta = columnMetadata.value[el.fieldName];
-            
+
             if (meta?.isAttachment) {
               pendingAttachments[el.fieldName] = [];
             } else {
-              pendingAttachments[el.fieldName] = defaultValue(meta);
+              formData[el.fieldName] = defaultValue(meta);
             }
           }
         });


### PR DESCRIPTION
Closes #22

After a successful submission, non-attachment fields were assigned to `pendingAttachments` instead of `formData`, leaving the form fields filled with the previously submitted values.

## Test plan

- [ ] Submit a form with values in text/numeric/date/select/checkbox fields
- [ ] After "Votre réponse a bien été enregistrée" appears, all fields should be empty/reset to default