### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gristgouv/grist-cw-intra-form/security/code-scanning/1](https://github.com/gristgouv/grist-cw-intra-form/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.

Best fix for this file: in `.github/workflows/test.yml`, add a top-level `permissions` section after the `on` block (or before `jobs`) with:

- `contents: read`

This preserves existing behavior (checkout + install + test) while documenting and enforcing minimal access for all jobs in this workflow. No imports/methods/dependencies are needed since this is YAML config only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
